### PR TITLE
Add opt-in hybrid prefix-state cache and SSE timing compatibility

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -102,6 +102,7 @@ When BF16 is selected for experts or major components, treat that run as validat
 | `--hcs-host-cache-mode MODE` | source | Soft HCS host storage: `source`, `mirror`, or `auto` |
 | `--dynamic-hcs` / `--no-dynamic-hcs` | on | Dynamic HCS: protect the high-ranked heatmap prefix and reserve a recency-adaptive tail |
 | `--dynamic-hcs-tail-blocks N` | 2 | Advanced dynamic HCS recency-tail size, measured in activated-expert blocks; valid range `1..5` |
+| `--prefix-cache` / `--no-prefix-cache` | off | Experimental single-lineage exact-prefix reuse for KV and recurrent sequence state |
 | `--vram-safety-margin N` | 600 | Reserved VRAM in MB below which warnings fire |
 | `--stream-attention` | off | Stream attention weights from CPU (for very large models) |
 | `--force-load` | — | Override RAM safety checks and load anyway |
@@ -110,6 +111,18 @@ When BF16 is selected for experts or major components, treat that run as validat
 | `--heatmap-path PATH` | — | Path to expert_heatmap.json for HCS init |
 | `--approved-heatmap-mode MODE` | auto | Approved route-heatmap lookup: `auto`, `off`, or `require` |
 | `--approved-heatmap-manifest-url URL` | GitHub manifest | Override the approved route-heatmap manifest URL |
+
+`--prefix-cache` is deliberately opt-in. It reuses a live prefix only when the
+new rendered token sequence is an exact non-empty append and falls back to a
+full prefill on mismatch or uncertain state. Requests that can use a
+speculative draft model are never retained, because draft verification advances
+device state in batches that per-token accounting cannot certify. The
+persistent config key is `CFG_PREFIX_CACHE=1`.
+
+`--sse-timing-compat` is a separate opt-in protocol workaround. It adds a
+neutral empty-delta choice to Krasis's final timing-only SSE chunk for clients
+that reject an empty `choices` array; it does not alter normal content or tool
+chunks. The persistent config key is `CFG_SSE_TIMING_COMPAT=1`.
 
 Dynamic HCS uses the same physical HCS residency table as the heatmap cache.
 It does not create a second cache or allow duplicate expert residency across a

--- a/PREFIX_CACHE_PLAN.md
+++ b/PREFIX_CACHE_PLAN.md
@@ -1,0 +1,216 @@
+# Hybrid Prefix-State Cache Plan
+
+## Goal
+
+Avoid re-prefilling an unchanged conversation prefix on every compatible chat
+request while preserving the model's exact existing results. Hybrid models must
+reuse both kinds of sequence state:
+
+- paged KV state for full/GQA attention layers;
+- recurrent and convolution state for linear-attention layers (and the
+  equivalent recurrent state for other supported hybrid layer types).
+
+This is an experimental, opt-in feature. It is **disabled by default**.
+With it disabled, requests must follow the current full-prefill path without
+additional state mutation, cache lookup, or changed sampling behavior.
+
+## User-facing switch
+
+Add one persistent launcher setting and one CLI override:
+
+- `CFG_PREFIX_CACHE="0"` by default;
+- `--prefix-cache` enables it;
+- `--no-prefix-cache` explicitly disables it.
+
+Pass the resolved boolean explicitly from the Python server to `RustServer`;
+do not use a hidden always-on environment variable. Log the resolved state once
+at startup. A later PR may promote the default only after correctness and
+stability data justify it.
+
+## Independent SSE compatibility switch
+
+Keep the existing trailing-timing-chunk compatibility fix separate from prefix
+caching and opt-in:
+
+- `CFG_SSE_TIMING_COMPAT="0"` by default;
+- `--sse-timing-compat` enables it;
+- `--no-sse-timing-compat` explicitly disables it.
+
+With the switch off, retain upstream's empty `choices` array in the custom
+timing SSE chunk. With it on, emit one neutral OpenAI-compatible choice with an
+empty delta. No normal content, tool-call, finish, or `[DONE]` chunk may change.
+Unit tests must cover both exact JSON shapes.
+
+## First implementation scope
+
+Implement a single-lineage, exact-token continuation cache. Krasis currently
+serializes model requests, so one retained live state is enough to accelerate
+the common agent workflow without introducing a radix tree or a VRAM-resident
+multi-session cache.
+
+The cache records:
+
+- the exact token IDs represented by the retained device state;
+- the represented sequence position;
+- model/runtime compatibility metadata needed for safe reuse;
+- hit, miss, invalidation, reused-token, and suffix-token counters.
+
+The retained device state consists of the already-live state on every pipeline
+GPU. No second full KV allocation is introduced in this phase.
+
+## Eligibility and lookup
+
+A request is a cache hit only when all of the following are true:
+
+1. the feature is enabled;
+2. the request has no image or other external prefill embeddings;
+3. a valid retained state exists from a completed request;
+4. the new rendered prompt's token IDs start with the complete retained token
+   sequence, compared token-for-token;
+5. the retained position and every device store agree;
+6. the suffix is non-empty and the resulting context fits the configured KV
+   capacity;
+7. no intervening endpoint or failure invalidated sequence state.
+
+Sampling parameters do not invalidate a deterministic prefix state. Changes to
+messages, tools, chat template output, tokenizer output, or model identity
+naturally miss because the token sequence differs.
+
+Two additional eligibility rules hold in the implementation:
+
+- prompts that overflow the KV capacity stay on the fully validated
+  fresh-prefill path so their existing error contract is unchanged;
+- requests that can use a speculative draft model never promote an entry,
+  because batched draft verification and its recurrent-state rollback break
+  per-token consumed accounting.
+
+On any uncertainty, log a miss reason, invalidate the entry, and use the
+existing full-prefill path.
+
+## State-position accounting
+
+Correct token accounting is the central invariant.
+
+Prefill produces the first sampled token while device state initially
+represents the prompt. Each decode step consumes one token and advances device
+state before selecting the next token. The implementation must record only
+tokens that have actually been consumed by the model. An emitted token that has
+not yet been consumed must not be included in the cached prefix.
+
+Before enabling reuse, add tests around a small pure-Rust state tracker that
+models:
+
+- normal EOS completion;
+- max-token completion;
+- stop-string completion;
+- client disconnect/write failure;
+- tool-call output;
+- zero/one-token completion.
+
+Promotion of a new cache entry happens only after all GPU pipeline segments
+have completed the same decode position and the exact consumed-token list is
+known.
+
+## Continuation prefill
+
+Add a separate continuation-prefill entry point rather than weakening the
+fresh-prefill contract:
+
+- fresh prefill keeps its current state resets and position zero;
+- continuation prefill receives `prefix_len` and only the suffix token IDs;
+- it does not zero KV, recurrent, convolution, or Mamba state;
+- RoPE/GQA positions and ring/cache indices start at `prefix_len`;
+- chunk positions are absolute even though scratch buffers contain only the
+  suffix;
+- continuation bypasses the stage-exact temporary KV cache and appends suffix
+  positions directly to the registered decode cache, preserving the retained
+  prefix;
+- updated recurrent state is left in the same decode-store buffers;
+- auxiliary pipeline stores are advanced consistently, without overwriting a
+  valid retained prefix with reset state.
+
+If continuation setup or execution fails before any state mutation, fall back
+to full prefill. If it fails after mutation may have begun, invalidate and run
+the existing full reset/prefill path. Never continue decoding from partially
+advanced state.
+
+## Invalidation
+
+Invalidate the live entry before or after these operations as appropriate:
+
+- any full prefill;
+- `/v1/internal/prefill_logits` or reference/benchmark endpoints that reuse the
+  same device state;
+- multimodal prefill;
+- model/runtime reconfiguration;
+- sequence overflow or ring-window wrap not explicitly validated;
+- CUDA, prefill, decode, aux-copy, or cleanup error;
+- cancellation where consumed-token accounting is uncertain;
+- exact-prefix mismatch.
+
+The first version deliberately supports one conversation lineage. An unrelated
+request replaces it via full prefill; returning to an older branch is a miss.
+
+`RustServer::benchmark_request` mutates device sequence state from a Python
+thread without access to the server request loop. It bumps a global
+sequence-state epoch on entry and exit; cache entries record the epoch captured
+before their request's prefill and any epoch change forces a miss and
+invalidation.
+
+## Observability
+
+Emit one concise per-request cache line:
+
+`prefix_cache=hit|miss|disabled reason=... cached=N reused=N suffix=N`
+
+Expose aggregate counters in existing timing/benchmark JSON where practical:
+
+- lookups, hits, misses, invalidations;
+- reused prompt tokens and suffix-prefilled tokens;
+- continuation-prefill milliseconds;
+- full-prefill milliseconds.
+
+Do not call HCS expert residency a prefix-cache hit rate; it is a separate
+weight-residency mechanism.
+
+## Test and validation sequence
+
+1. Pure Rust unit tests for exact-prefix matching, state tracking, invalidation,
+   and disabled-mode behavior.
+2. Python config/CLI tests proving the default is off and both CLI overrides
+   work.
+3. Existing non-GPU test suite with the feature disabled.
+4. Small-model equivalence test:
+   - run the same multi-turn prompts with cache off and on;
+   - greedy decode must produce identical token IDs;
+   - compare selected logits at the continuation boundary within the existing
+     backend's established tolerance.
+5. Hybrid-model equivalence test covering both KV and recurrent layers.
+6. Multi-GPU test proving every pipeline segment reaches the same position.
+7. Fault tests for mismatch, disconnect, forced prefill error, and aux-copy
+   error, followed by a clean request that must match cache-off output.
+8. Agent benchmark comparison:
+   - same patch quality/resolution result;
+   - materially lower repeated-prefix prefill time;
+   - report hit rate and reused tokens;
+   - no new tool-protocol or streaming failures.
+
+## Acceptance criteria
+
+- Feature remains disabled unless explicitly enabled.
+- Cache-off path has no behavioral or performance regression beyond trivial
+  startup/config plumbing.
+- Cache-on greedy output is token-identical to cache-off for validated
+  single- and multi-GPU hybrid tests.
+- Any mismatch or uncertain state safely falls back to full prefill.
+- Long agent conversations show prefix hits and reduced prefill work.
+- SSE timing compatibility is independently opt-in and its disabled path
+  preserves the upstream timing-chunk shape.
+
+## Deferred work
+
+- Multi-entry radix/paged prefix cache.
+- Host snapshots or device snapshots for conversation branching.
+- Cross-process persistence.
+- Multimodal prefix reuse.
+- Automatic default enablement.

--- a/python/krasis/launcher.py
+++ b/python/krasis/launcher.py
@@ -585,7 +585,8 @@ CONFIG_KEYS = [
     "CFG_STREAM_ATTENTION", "CFG_DRAFT_MODEL", "CFG_DRAFT_K", "CFG_DRAFT_CONTEXT",
     "CFG_TEMPERATURE",
     "CFG_FORCE_LOAD", "CFG_FORCE_REBUILD_CACHE", "CFG_FORCE_REBUILD_HQQ_CACHE",
-    "CFG_BUILD_CACHE", "CFG_ENABLE_THINKING",
+    "CFG_BUILD_CACHE", "CFG_ENABLE_THINKING", "CFG_PREFIX_CACHE",
+    "CFG_SSE_TIMING_COMPAT",
 ]
 
 
@@ -686,6 +687,8 @@ class LauncherConfig:
         self.force_rebuild_hqq_cache: bool = False
         self.build_cache: bool = False
         self.enable_thinking: bool = True
+        self.prefix_cache: bool = False
+        self.sse_timing_compat: bool = False
 
     def apply_saved(self, saved: Dict[str, str]) -> None:
         """Apply loaded config values."""
@@ -910,6 +913,10 @@ class LauncherConfig:
             self.build_cache = saved["CFG_BUILD_CACHE"] == "1"
         if "CFG_ENABLE_THINKING" in saved:
             self.enable_thinking = saved["CFG_ENABLE_THINKING"] != "0"
+        if "CFG_PREFIX_CACHE" in saved:
+            self.prefix_cache = saved["CFG_PREFIX_CACHE"] == "1"
+        if "CFG_SSE_TIMING_COMPAT" in saved:
+            self.sse_timing_compat = saved["CFG_SSE_TIMING_COMPAT"] == "1"
 
     def to_save_dict(self) -> Dict[str, Any]:
         """Convert to dict for saving or launch config serialization."""
@@ -960,6 +967,8 @@ class LauncherConfig:
             "CFG_FORCE_REBUILD_HQQ_CACHE": "1" if self.force_rebuild_hqq_cache else "",
             "CFG_BUILD_CACHE": "1" if self.build_cache else "",
             "CFG_ENABLE_THINKING": "1" if self.enable_thinking else "0",
+            "CFG_PREFIX_CACHE": "1" if self.prefix_cache else "0",
+            "CFG_SSE_TIMING_COMPAT": "1" if self.sse_timing_compat else "0",
         }
         if self.attention_quant in ("hqq46_auto", "hqq68_auto"):
             values["CFG_HQQ_AUTO_BUDGET_PCT"] = str(self.hqq_auto_budget_pct)
@@ -1025,6 +1034,10 @@ OPTIONS = [
     ConfigOption("SSH Key Path", "ssh_key_path", opt_type="text", advanced=True),
     ConfigOption("Enable thinking", "enable_thinking",
                  choices=[True, False]),
+    ConfigOption("Prefix-state cache", "prefix_cache",
+                 choices=[False, True], advanced=True),
+    ConfigOption("SSE timing compatibility", "sse_timing_compat",
+                 choices=[False, True], advanced=True),
     ConfigOption("HCS RAM saver", "hcs_host_cache_mode",
                  choices=["source", "mirror", "auto"]),
     ConfigOption("Adaptive cold-mass pruning", "adaptive_cold_mass_pruning",
@@ -2823,6 +2836,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--dynamic-hcs", action=argparse.BooleanOptionalAction,
                         default=None,
                         help="Enable dynamic HCS heatmap-prefix + recency-tail cache (default: on)")
+    parser.add_argument("--prefix-cache", action=argparse.BooleanOptionalAction,
+                        default=None,
+                        help="Enable experimental exact-prefix KV + recurrent-state reuse (default: off)")
+    parser.add_argument("--sse-timing-compat", action=argparse.BooleanOptionalAction,
+                        default=None,
+                        help="Emit a compatibility choice in the final SSE timing chunk (default: off)")
     parser.add_argument("--dynamic-hcs-tail-blocks", type=int, default=None,
                         choices=[1, 2, 3, 4, 5],
                         help="Advanced: recency tail size in activated-expert blocks (1-5, default: 2)")
@@ -2938,6 +2957,10 @@ def _apply_cli_overrides(cfg: LauncherConfig, args: argparse.Namespace) -> None:
         cfg.gpu_prefill_threshold = args.gpu_prefill_threshold
     if args.dynamic_hcs is not None:
         cfg.dynamic_hcs = bool(args.dynamic_hcs)
+    if args.prefix_cache is not None:
+        cfg.prefix_cache = bool(args.prefix_cache)
+    if args.sse_timing_compat is not None:
+        cfg.sse_timing_compat = bool(args.sse_timing_compat)
     if args.dynamic_hcs_tail_blocks is not None:
         cfg.dynamic_hcs_tail_blocks = int(args.dynamic_hcs_tail_blocks)
     if args.hcs_host_cache_mode is not None:

--- a/python/krasis/model.py
+++ b/python/krasis/model.py
@@ -10760,11 +10760,13 @@ class KrasisModel:
         torch.cuda.synchronize(device)
         logger.info("Uploaded prefill-only attention: ~%.0f MB", uploaded_bytes / 1024 / 1024)
 
-    def server_cleanup(self):
+    def server_cleanup(self, preserve_sequence_state: bool = False):
         """Free server request state (KV cache pages, etc.).
 
         Also handles single-slot AWQ: restore Marlin data into GPU slots
-        for instant prefill on the next request.
+        for instant prefill on the next request. The experimental prefix cache
+        may retain the exact live KV and recurrent state for one continuation;
+        all existing callers keep the full-reset default.
         """
         # Single-slot AWQ: restore Marlin into slots
         gpu_store = getattr(self, '_gpu_decode_store', None)
@@ -10778,18 +10780,19 @@ class KrasisModel:
                     s.free()
             self._server_seq_states = None
 
-        # Request-scoped recurrent state must be reset alongside KV cleanup.
-        # Otherwise an internal test request can leak LA/Mamba decode state into
-        # the next chat request even though the KV pages were freed.
-        if self.cfg.is_hybrid:
-            for layer in self.layers:
-                if layer.layer_type == "linear_attention":
-                    layer.attention.reset_state()
+        if not preserve_sequence_state:
+            # Request-scoped recurrent state must be reset alongside KV cleanup.
+            # Otherwise an internal test request can leak LA/Mamba decode state
+            # into the next chat request even though the KV pages were freed.
+            if self.cfg.is_hybrid:
+                for layer in self.layers:
+                    if layer.layer_type == "linear_attention":
+                        layer.attention.reset_state()
 
-        decode_states = getattr(self, '_mamba2_decode_states', None)
-        if decode_states:
-            for buffers in decode_states.values():
-                buffers['conv_state'].zero_()
-                buffers['ssm_state'].zero_()
+            decode_states = getattr(self, '_mamba2_decode_states', None)
+            if decode_states:
+                for buffers in decode_states.values():
+                    buffers['conv_state'].zero_()
+                    buffers['ssm_state'].zero_()
 
         self._rust_kv_refs = None

--- a/python/krasis/server.py
+++ b/python/krasis/server.py
@@ -2013,6 +2013,8 @@ def main():
             "CFG_DRAFT_CONTEXT": "draft_context",
             "CFG_TEMPERATURE": "temperature",
             "CFG_ENABLE_THINKING": "enable_thinking",
+            "CFG_PREFIX_CACHE": "prefix_cache",
+            "CFG_SSE_TIMING_COMPAT": "sse_timing_compat",
             "CFG_SESSION_ENABLED": None,  # Session messenger integration removed; ignore old saved configs
             "CFG_NUM_GPUS": "num_gpus",
             "CFG_CPU_DECODE": None,  # CPU decode removed, ignore config key
@@ -2024,6 +2026,8 @@ def main():
             "CFG_FORCE_REBUILD_HQQ_CACHE",
             "CFG_BUILD_CACHE",
             "CFG_ENABLE_THINKING",
+            "CFG_PREFIX_CACHE",
+            "CFG_SSE_TIMING_COMPAT",
             "CFG_HCS",
             "CFG_MULTI_GPU_HCS",
             "CFG_DYNAMIC_HCS",
@@ -2260,6 +2264,12 @@ def main():
     parser.add_argument("--enable-thinking", action=argparse.BooleanOptionalAction,
                         default=True,
                         help="Enable thinking/reasoning mode (default: on)")
+    parser.add_argument("--prefix-cache", action=argparse.BooleanOptionalAction,
+                        default=False,
+                        help="Enable experimental exact-prefix KV + recurrent-state reuse (default: off)")
+    parser.add_argument("--sse-timing-compat", action=argparse.BooleanOptionalAction,
+                        default=False,
+                        help="Emit a compatibility choice in the final SSE timing chunk (default: off)")
     parser.add_argument("--test-endpoints", action="store_true", default=False,
                         help="Enable test-only endpoints (/v1/internal/prefill_logits)")
     # Apply config file defaults, then parse CLI (CLI wins over config file)
@@ -4103,6 +4113,8 @@ def main():
         all_multi_gpu_gqa_offsets,
         _vision_supported,
         test_endpoints=getattr(args, 'test_endpoints', False),
+        prefix_cache_enabled=getattr(args, 'prefix_cache', False),
+        sse_timing_compat=getattr(args, 'sse_timing_compat', False),
     )
     ssh_tunnel = None
     if str(getattr(args, "ssh_tunnel", "") or "").strip():

--- a/src/gpu_decode.rs
+++ b/src/gpu_decode.rs
@@ -22354,7 +22354,7 @@ impl GpuDecodeStore {
 
     /// Check if a draft model is loaded.
     #[getter]
-    fn has_draft_model(&self) -> bool {
+    pub fn has_draft_model(&self) -> bool {
         self.draft.is_some()
     }
 
@@ -41913,6 +41913,160 @@ impl GpuDecodeStore {
 
         log::info!(
             "copy_la_states_to_aux: copied {} LA layers, {} bytes total",
+            copied,
+            total_bytes
+        );
+        Ok(())
+    }
+
+    /// Copy Mamba2 recurrent state (conv_state + SSM state) from this store
+    /// to another store for layers within [layer_start..layer_end).
+    ///
+    /// The method is intentionally direction-agnostic despite the historical
+    /// `to_aux` name: the prefix cache also uses it to gather state from each
+    /// owning auxiliary GPU back to the primary store after decode.
+    pub fn copy_mamba2_states_to_aux(
+        &self,
+        aux_store: &mut GpuDecodeStore,
+        layer_start: usize,
+        layer_end: usize,
+    ) -> Result<(), String> {
+        let graph = self.graph.as_ref().ok_or("source graph not configured")?;
+        let aux_graph = aux_store
+            .graph
+            .as_ref()
+            .ok_or("destination graph not configured")?;
+
+        let mut copied = 0usize;
+        let mut total_bytes = 0usize;
+
+        for layer_idx in layer_start..layer_end {
+            let (conv_src, ssm_src, conv_bytes, ssm_bytes) =
+                match &graph.layers[layer_idx].attn {
+                    GpuAttnConfig::Mamba2 {
+                        conv_state_ptr,
+                        ssm_state_ptr,
+                        conv_dim,
+                        conv_kernel,
+                        num_heads,
+                        head_dim,
+                        state_size,
+                        ..
+                    } => (
+                        *conv_state_ptr,
+                        *ssm_state_ptr,
+                        conv_dim.saturating_mul(*conv_kernel).saturating_mul(4),
+                        num_heads
+                            .saturating_mul(*head_dim)
+                            .saturating_mul(*state_size)
+                            .saturating_mul(4),
+                    ),
+                    _ => continue,
+                };
+
+            if conv_src == 0 || ssm_src == 0 {
+                continue;
+            }
+
+            let (conv_dst, ssm_dst) = match &aux_graph.layers[layer_idx].attn {
+                GpuAttnConfig::Mamba2 {
+                    conv_state_ptr,
+                    ssm_state_ptr,
+                    ..
+                } => (*conv_state_ptr, *ssm_state_ptr),
+                _ => {
+                    return Err(format!(
+                        "Destination store layer {} is not Mamba2 but source is",
+                        layer_idx
+                    ))
+                }
+            };
+            if conv_dst == 0 || ssm_dst == 0 {
+                return Err(format!(
+                    "Destination store missing Mamba2 state buffers for layer {}",
+                    layer_idx
+                ));
+            }
+
+            let mut host_buf = vec![0u8; conv_bytes.max(ssm_bytes)];
+            self.device
+                .bind_to_thread()
+                .map_err(|e| format!("bind source GPU for Mamba2 copy: {:?}", e))?;
+            self.device
+                .synchronize()
+                .map_err(|e| format!("sync source GPU before Mamba2 copy: {:?}", e))?;
+
+            unsafe {
+                let err = cuda_sys::lib().cuMemcpyDtoH_v2(
+                    host_buf.as_mut_ptr() as *mut std::ffi::c_void,
+                    conv_src,
+                    conv_bytes,
+                );
+                if err != cuda_sys::CUresult::CUDA_SUCCESS {
+                    return Err(format!(
+                        "Mamba2 conv_state D2H layer {}: {:?}",
+                        layer_idx, err
+                    ));
+                }
+            }
+            aux_store
+                .device
+                .bind_to_thread()
+                .map_err(|e| format!("bind destination GPU for Mamba2 copy: {:?}", e))?;
+            unsafe {
+                let err = cuda_sys::lib().cuMemcpyHtoD_v2(
+                    conv_dst,
+                    host_buf.as_ptr() as *const std::ffi::c_void,
+                    conv_bytes,
+                );
+                if err != cuda_sys::CUresult::CUDA_SUCCESS {
+                    return Err(format!(
+                        "Mamba2 conv_state H2D layer {}: {:?}",
+                        layer_idx, err
+                    ));
+                }
+            }
+
+            self.device
+                .bind_to_thread()
+                .map_err(|e| format!("bind source GPU for Mamba2 SSM copy: {:?}", e))?;
+            unsafe {
+                let err = cuda_sys::lib().cuMemcpyDtoH_v2(
+                    host_buf.as_mut_ptr() as *mut std::ffi::c_void,
+                    ssm_src,
+                    ssm_bytes,
+                );
+                if err != cuda_sys::CUresult::CUDA_SUCCESS {
+                    return Err(format!(
+                        "Mamba2 SSM state D2H layer {}: {:?}",
+                        layer_idx, err
+                    ));
+                }
+            }
+            aux_store
+                .device
+                .bind_to_thread()
+                .map_err(|e| format!("bind destination GPU for Mamba2 SSM copy: {:?}", e))?;
+            unsafe {
+                let err = cuda_sys::lib().cuMemcpyHtoD_v2(
+                    ssm_dst,
+                    host_buf.as_ptr() as *const std::ffi::c_void,
+                    ssm_bytes,
+                );
+                if err != cuda_sys::CUresult::CUDA_SUCCESS {
+                    return Err(format!(
+                        "Mamba2 SSM state H2D layer {}: {:?}",
+                        layer_idx, err
+                    ));
+                }
+            }
+
+            copied += 1;
+            total_bytes += conv_bytes + ssm_bytes;
+        }
+
+        log::info!(
+            "copy_mamba2_states_to_aux: copied {} Mamba2 layers, {} bytes total",
             copied,
             total_bytes
         );

--- a/src/gpu_prefill.rs
+++ b/src/gpu_prefill.rs
@@ -18494,6 +18494,32 @@ impl PrefillEngine {
     /// Flow: sync GPU → trim cudarc pool (release HCS soft VRAM) → measure free
     /// VRAM → compute chunk_size → drop old scratch → allocate new scratch.
     pub fn prepare_for_prefill(&mut self, prompt_tokens: usize) -> Result<(), String> {
+        self.prepare_for_prefill_internal(prompt_tokens, false)
+    }
+
+    /// Allocate scratch for an exact-prefix continuation while retaining the
+    /// live decode KV and recurrent state. `total_prompt_tokens` is used for
+    /// attention staging capacity; only `suffix_tokens` will be computed by
+    /// `run_continuation_prefill`.
+    pub fn prepare_for_continuation_prefill(
+        &mut self,
+        total_prompt_tokens: usize,
+        suffix_tokens: usize,
+    ) -> Result<(), String> {
+        if suffix_tokens == 0 || suffix_tokens >= total_prompt_tokens {
+            return Err(format!(
+                "invalid continuation sizes: total_prompt_tokens={} suffix_tokens={}",
+                total_prompt_tokens, suffix_tokens
+            ));
+        }
+        self.prepare_for_prefill_internal(total_prompt_tokens, true)
+    }
+
+    fn prepare_for_prefill_internal(
+        &mut self,
+        prompt_tokens: usize,
+        preserve_sequence_state: bool,
+    ) -> Result<(), String> {
         self.bind_cuda_context()?;
         self.refresh_trace_config();
         trace_emit_prefill_global_mark(
@@ -18613,7 +18639,12 @@ impl PrefillEngine {
                 );
             }
         }
-        if !skip_stage_exact_single_chunk {
+        if preserve_sequence_state {
+            // Continuation prefill must append directly to the decode cache.
+            // A stage-exact temporary cache would hide the retained prefix and
+            // its final export would overwrite prefix positions.
+            self.release_prefill_kv_temp();
+        } else if !skip_stage_exact_single_chunk {
             self.setup_stage_exact_prefill_kv(prompt_tokens)?;
         }
         // Old scratch + prefill buffers now dropped, VRAM is freed.
@@ -19317,17 +19348,70 @@ impl PrefillEngine {
         temperature: f32,
         suppress_tokens: &[u32],
     ) -> Result<PrefillResult, String> {
+        self.run_prefill_internal(token_ids, 0, true, temperature, suppress_tokens)
+    }
+
+    /// Prefill only tokens appended after an exact retained prefix.
+    ///
+    /// Unlike `run_prefill`, this keeps registered KV, convolution, Mamba, and
+    /// linear-attention recurrent state intact and assigns absolute positions
+    /// beginning at `prefix_len`.
+    pub fn run_continuation_prefill(
+        &mut self,
+        suffix_token_ids: &[u32],
+        prefix_len: usize,
+        temperature: f32,
+        suppress_tokens: &[u32],
+    ) -> Result<PrefillResult, String> {
+        if prefix_len == 0 || suffix_token_ids.is_empty() {
+            return Err(format!(
+                "invalid continuation prefill: prefix_len={} suffix_tokens={}",
+                prefix_len,
+                suffix_token_ids.len()
+            ));
+        }
+        self.run_prefill_internal(
+            suffix_token_ids,
+            prefix_len,
+            false,
+            temperature,
+            suppress_tokens,
+        )
+    }
+
+    fn run_prefill_internal(
+        &mut self,
+        token_ids: &[u32],
+        position_offset: usize,
+        reset_sequence_state: bool,
+        temperature: f32,
+        suppress_tokens: &[u32],
+    ) -> Result<PrefillResult, String> {
         // Bind CUDA context to calling thread (needed for cross-thread use)
         self.bind_cuda_context()?;
         self.refresh_trace_config();
 
         let t0 = Instant::now();
         let total_m = token_ids.len();
+        let resulting_prompt_len = position_offset
+            .checked_add(total_m)
+            .ok_or("prefill position overflow")?;
         let h = self.config.hidden_size;
         let num_hidden_layers = self.config.num_hidden_layers;
         let liveness_timing = prefill_liveness_timing_enabled();
         if total_m == 0 {
             return Err("Empty token sequence".to_string());
+        }
+        // Guard the continuation path only: fresh prefill keeps the existing
+        // post-prefill kv_overflow handling and error contract unchanged.
+        if position_offset > 0
+            && self.decode_kv_max_seq > 0
+            && resulting_prompt_len > self.decode_kv_max_seq
+        {
+            return Err(format!(
+                "KV cache exhausted: continuation end {} exceeds max_seq {}",
+                resulting_prompt_len, self.decode_kv_max_seq
+            ));
         }
         let _ = self.first_token_margin_projection_target()?;
         let _ = self.read_only_checkpoint_config()?;
@@ -19422,71 +19506,74 @@ impl PrefillEngine {
             );
         }
 
-        // Zero recurrent state for fresh prefill (each prefill processes a full prompt).
-        if let Some(ref la_state_buf) = self.scratch.d_la_state {
-            let nv = self.config.la_num_v_heads;
-            let dk = self.config.la_k_head_dim;
-            let dv = self.config.la_v_head_dim;
-            let state_elems = nv * dk * dv;
-            unsafe {
-                cuda_sys::lib().cuMemsetD32Async(
-                    *la_state_buf.device_ptr(),
-                    0,
-                    state_elems,
-                    self.stream,
-                );
-            }
-        }
-        for layer_idx in 0..num_hidden_layers {
-            let lw = &self.layer_weights[layer_idx];
-            if lw.mamba2_conv_state_ptr != 0 {
-                let conv_dim = self.config.mamba_conv_dim;
-                let conv_kernel = self.config.mamba_conv_kernel;
-                unsafe {
-                    cuda_sys::lib().cuMemsetD32Async(
-                        lw.mamba2_conv_state_ptr,
-                        0,
-                        conv_dim * conv_kernel,
-                        self.stream,
-                    );
-                }
-            }
-            if lw.mamba2_ssm_state_ptr != 0 {
-                let n_heads = self.config.mamba_num_heads;
-                let head_dim = self.config.mamba_head_dim;
-                let d_state = self.config.mamba_d_state;
-                unsafe {
-                    cuda_sys::lib().cuMemsetD32Async(
-                        lw.mamba2_ssm_state_ptr,
-                        0,
-                        n_heads * head_dim * d_state,
-                        self.stream,
-                    );
-                }
-            }
-            if lw.la_conv_state_ptr != 0 {
-                let conv_dim = self.config.la_conv_dim;
-                let kernel_dim = self.config.la_conv_kernel_dim;
-                unsafe {
-                    cuda_sys::lib().cuMemsetD32Async(
-                        lw.la_conv_state_ptr,
-                        0,
-                        conv_dim * kernel_dim,
-                        self.stream,
-                    );
-                }
-            }
-            if lw.la_recur_state_ptr != 0 {
+        // Fresh prefill resets all sequence state. Exact-prefix continuation
+        // deliberately retains it and appends from `position_offset`.
+        if reset_sequence_state {
+            if let Some(ref la_state_buf) = self.scratch.d_la_state {
                 let nv = self.config.la_num_v_heads;
                 let dk = self.config.la_k_head_dim;
                 let dv = self.config.la_v_head_dim;
+                let state_elems = nv * dk * dv;
                 unsafe {
                     cuda_sys::lib().cuMemsetD32Async(
-                        lw.la_recur_state_ptr,
+                        *la_state_buf.device_ptr(),
                         0,
-                        nv * dk * dv,
+                        state_elems,
                         self.stream,
                     );
+                }
+            }
+            for layer_idx in 0..num_hidden_layers {
+                let lw = &self.layer_weights[layer_idx];
+                if lw.mamba2_conv_state_ptr != 0 {
+                    let conv_dim = self.config.mamba_conv_dim;
+                    let conv_kernel = self.config.mamba_conv_kernel;
+                    unsafe {
+                        cuda_sys::lib().cuMemsetD32Async(
+                            lw.mamba2_conv_state_ptr,
+                            0,
+                            conv_dim * conv_kernel,
+                            self.stream,
+                        );
+                    }
+                }
+                if lw.mamba2_ssm_state_ptr != 0 {
+                    let n_heads = self.config.mamba_num_heads;
+                    let head_dim = self.config.mamba_head_dim;
+                    let d_state = self.config.mamba_d_state;
+                    unsafe {
+                        cuda_sys::lib().cuMemsetD32Async(
+                            lw.mamba2_ssm_state_ptr,
+                            0,
+                            n_heads * head_dim * d_state,
+                            self.stream,
+                        );
+                    }
+                }
+                if lw.la_conv_state_ptr != 0 {
+                    let conv_dim = self.config.la_conv_dim;
+                    let kernel_dim = self.config.la_conv_kernel_dim;
+                    unsafe {
+                        cuda_sys::lib().cuMemsetD32Async(
+                            lw.la_conv_state_ptr,
+                            0,
+                            conv_dim * kernel_dim,
+                            self.stream,
+                        );
+                    }
+                }
+                if lw.la_recur_state_ptr != 0 {
+                    let nv = self.config.la_num_v_heads;
+                    let dk = self.config.la_k_head_dim;
+                    let dv = self.config.la_v_head_dim;
+                    unsafe {
+                        cuda_sys::lib().cuMemsetD32Async(
+                            lw.la_recur_state_ptr,
+                            0,
+                            nv * dk * dv,
+                            self.stream,
+                        );
+                    }
                 }
             }
         }
@@ -19873,10 +19960,16 @@ impl PrefillEngine {
             let chunk_end = std::cmp::min(chunk_start + planned_chunk_tokens, total_m);
             let m = chunk_end.saturating_sub(chunk_start);
             let chunk_tokens = &token_ids[chunk_start..chunk_end];
+            let absolute_chunk_start = position_offset
+                .checked_add(chunk_start)
+                .ok_or("continuation prefill position overflow")?;
+            let absolute_chunk_end = position_offset
+                .checked_add(chunk_end)
+                .ok_or("continuation prefill position overflow")?;
             self.active_prefill_chunk_idx = chunk_idx;
-            self.active_prefill_chunk_start = chunk_start;
+            self.active_prefill_chunk_start = absolute_chunk_start;
             let chunk_tok0 = chunk_tokens.first().copied().unwrap_or(0) as usize;
-            let chunk_last_pos = chunk_end.saturating_sub(1);
+            let chunk_last_pos = absolute_chunk_end.saturating_sub(1);
             let chunk_last_tok = chunk_tokens.last().copied().unwrap_or(0) as usize;
             let chunk_t0 = if debug_prefill {
                 Some(Instant::now())
@@ -19889,8 +19982,8 @@ impl PrefillEngine {
                     "chunk_start chunk={} total_chunks={} start={} end={} tokens={} tok0={} last_pos={} last_tok={}",
                     chunk_idx,
                     num_chunks,
-                    chunk_start,
-                    chunk_end,
+                    absolute_chunk_start,
+                    absolute_chunk_end,
                     m,
                     chunk_tok0,
                     chunk_last_pos,
@@ -19900,13 +19993,13 @@ impl PrefillEngine {
             trace_emit_prefill_mark(
                 self.trace.as_ref(),
                 chunk_idx,
-                chunk_start,
+                absolute_chunk_start,
                 chunk_tok0,
                 None,
                 "prefill_chunk",
                 &format!(
                     "phase=chunk_start chunk_tokens={} chunk_end={} total_chunks={}",
-                    m, chunk_end, num_chunks
+                    m, absolute_chunk_end, num_chunks
                 ),
             );
 
@@ -19929,7 +20022,7 @@ impl PrefillEngine {
 
             // 1. Upload token IDs and positions for this chunk
             let tc0 = Instant::now();
-            self.upload_tokens_with_offset(chunk_tokens, chunk_start)
+            self.upload_tokens_with_offset(chunk_tokens, absolute_chunk_start)
                 .map_err(|e| format!("upload_tokens chunk {}: {}", chunk_idx, e))?;
 
             // 2. Embedding lookup. Image requests provide already-scattered
@@ -20108,7 +20201,7 @@ impl PrefillEngine {
                     } else {
                         (0.0, 0.0, 0.0)
                     };
-                    self.forward_gemma4_layer(layer_idx, m, chunk_idx, chunk_start, true)?;
+                    self.forward_gemma4_layer(layer_idx, m, chunk_idx, absolute_chunk_start, true)?;
                     has_residual = false;
                     if timing {
                         self.stream_sync()?;
@@ -21115,7 +21208,7 @@ impl PrefillEngine {
                 let ta0 = Instant::now();
                 match layer_type {
                     0 => self
-                        .forward_gqa_chunked(layer_idx, m, chunk_start, true)
+                        .forward_gqa_chunked(layer_idx, m, absolute_chunk_start, true)
                         .map_err(|e| format!("gqa layer {}: {}", layer_idx, e))?,
                     1 => self
                         .forward_mamba2(layer_idx, m, chunk_idx, chunk_last_pos, chunk_last_tok)
@@ -21128,7 +21221,7 @@ impl PrefillEngine {
                         )?;
                     }
                     3 => self
-                        .forward_linear_attention(layer_idx, m, chunk_start)
+                        .forward_linear_attention(layer_idx, m, absolute_chunk_start)
                         .map_err(|e| format!("linear_attn layer {}: {}", layer_idx, e))?,
                     _ => {
                         self.memcpy_d2d(
@@ -22195,7 +22288,7 @@ impl PrefillEngine {
                 trace_emit_prefill_mark(
                     self.trace.as_ref(),
                     chunk_idx,
-                    chunk_start,
+                    absolute_chunk_start,
                     chunk_tok0,
                     Some(layer_idx),
                     "prefill_layer",
@@ -22207,8 +22300,8 @@ impl PrefillEngine {
                 eprintln!(
                     "[PREFILL-DEBUG] chunk idx={} start={} end={} tokens={} ms={:.1} tok_per_s={:.1}",
                     chunk_idx,
-                    chunk_start,
-                    chunk_end,
+                    absolute_chunk_start,
+                    absolute_chunk_end,
                     m,
                     chunk_ms,
                     m as f64 / (chunk_ms / 1000.0),
@@ -22225,7 +22318,7 @@ impl PrefillEngine {
             trace_emit_prefill_mark(
                 self.trace.as_ref(),
                 chunk_idx,
-                chunk_start,
+                absolute_chunk_start,
                 chunk_tok0,
                 None,
                 "prefill_chunk",
@@ -23265,7 +23358,7 @@ impl PrefillEngine {
 
         Ok(PrefillResult {
             first_token,
-            prompt_len: total_m,
+            prompt_len: resulting_prompt_len,
             prefill_time_ms: ms,
         })
     }
@@ -37908,8 +38001,10 @@ impl PrefillEngine {
 
                 // DEBUG: sync before FLA to catch conv/gate/repeat kernel errors
 
-                // Zero runtime FLA scratch/state buffers that the vendor recurrence
-                // treats as zero-initialized outputs for each request.
+                // Zero request-local FLA outputs. The initial recurrent state is
+                // zero only for the first prompt chunk; later chunks and exact
+                // prefix continuations begin from the registered FP32 decode
+                // state produced by the preceding prefill/decode work.
                 unsafe {
                     let _ = cuda_sys::lib().cuMemsetD8Async(
                         a_fla,
@@ -37929,12 +38024,45 @@ impl PrefillEngine {
                         (fla_nt * nv * dk * dv * 2) as usize,
                         self.stream,
                     );
-                    let _ = cuda_sys::lib().cuMemsetD8Async(
-                        h0_fla,
-                        0,
-                        (nv * dk * dv * 2) as usize,
-                        self.stream,
-                    );
+                }
+                if chunk_start == 0 {
+                    unsafe {
+                        let _ = cuda_sys::lib().cuMemsetD8Async(
+                            h0_fla,
+                            0,
+                            (nv * dk * dv * 2) as usize,
+                            self.stream,
+                        );
+                    }
+                } else {
+                    if lw.la_recur_state_ptr == 0 {
+                        return Err(format!(
+                            "linear-attention layer {} missing retained recurrent state at position {}",
+                            layer_idx, chunk_start
+                        ));
+                    }
+                    let d = dk
+                        .checked_mul(dv)
+                        .ok_or("linear-attention recurrent row width overflow")?;
+                    let threads =
+                        std::cmp::max(32, ((std::cmp::min(1024, d) + 31) / 32) * 32) as u32;
+                    let mut c0 = h0_fla;
+                    let mut c1 = lw.la_recur_state_ptr;
+                    let mut c2 = d as i32;
+                    unsafe {
+                        launch(
+                            self.kernels.la_fp32_to_bf16,
+                            (nv as u32, 1, 1),
+                            (threads, 1, 1),
+                            0,
+                            self.stream,
+                            &mut [
+                                &mut c0 as *mut _ as *mut std::ffi::c_void,
+                                &mut c1 as *mut _ as *mut std::ffi::c_void,
+                                &mut c2 as *mut _ as *mut std::ffi::c_void,
+                            ],
+                        )?;
+                    }
                 }
 
                 let stream_ptr = self.stream as *mut std::ffi::c_void;
@@ -41035,14 +41163,26 @@ impl PrefillEngine {
                     );
                 }
 
-                // 16. Initialize recurrent state (zero)
-                unsafe {
-                    let _ = cuda_sys::lib().cuMemsetD8Async(
-                        la_state,
-                        0,
-                        (nv * dk * dv * 4) as usize,
-                        self.stream,
-                    );
+                // 16. Initialize recurrent state. A non-zero absolute start
+                // means this is either a later outer prefill chunk or an exact
+                // cached-prefix continuation.
+                if chunk_start == 0 {
+                    unsafe {
+                        let _ = cuda_sys::lib().cuMemsetD8Async(
+                            la_state,
+                            0,
+                            (nv * dk * dv * 4) as usize,
+                            self.stream,
+                        );
+                    }
+                } else {
+                    if lw.la_recur_state_ptr == 0 {
+                        return Err(format!(
+                            "linear-attention layer {} missing retained recurrent state at position {}",
+                            layer_idx, chunk_start
+                        ));
+                    }
+                    self.memcpy_d2d(la_state, lw.la_recur_state_ptr, (nv * dk * dv * 4) as u64)?;
                 }
 
                 // 17. Chunk recurrence loop (zero-copy strided kernels)

--- a/src/server.rs
+++ b/src/server.rs
@@ -63,7 +63,7 @@ impl<'a> StreamDetokenizer<'a> {
 use pyo3::prelude::*;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::sync::Arc;
 use std::time::Instant;
@@ -131,6 +131,12 @@ struct ServerState {
     eos_stop_ids: Vec<usize>,
     /// Monotonic order for /v1/internal/reference_test requests.
     reference_test_request_order: u64,
+    /// Experimental exact-prefix KV + recurrent-state reuse.
+    /// Explicitly disabled unless enabled by launcher configuration.
+    prefix_cache: HybridPrefixCache,
+    /// Emit a non-empty OpenAI-compatible `choices` entry in the trailing
+    /// Krasis timing SSE chunk. Disabled by default to preserve upstream output.
+    sse_timing_compat: bool,
 }
 
 #[derive(Clone)]
@@ -138,6 +144,198 @@ struct ServerInfo {
     model_name: String,
     max_context_tokens: usize,
     supports_vision: bool,
+}
+
+/// Monotonic epoch for GPU sequence-state ownership. Entry points that mutate
+/// device sequence state without access to `ServerState` — currently the
+/// Python-driven `RustServer::benchmark_request` — bump it around their work so
+/// the prefix cache can detect that its retained state was replaced outside the
+/// request loop.
+static SEQUENCE_STATE_EPOCH: AtomicU64 = AtomicU64::new(0);
+
+fn sequence_state_epoch() -> u64 {
+    SEQUENCE_STATE_EPOCH.load(Ordering::SeqCst)
+}
+
+/// Bumps the sequence-state epoch on construction and again on drop, covering
+/// every exit path of the guarded scope.
+struct SequenceStateEpochGuard;
+
+impl SequenceStateEpochGuard {
+    fn new() -> Self {
+        SEQUENCE_STATE_EPOCH.fetch_add(1, Ordering::SeqCst);
+        SequenceStateEpochGuard
+    }
+}
+
+impl Drop for SequenceStateEpochGuard {
+    fn drop(&mut self) {
+        SEQUENCE_STATE_EPOCH.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct PrefixCacheStats {
+    lookups: u64,
+    hits: u64,
+    misses: u64,
+    invalidations: u64,
+    reused_tokens: u64,
+    suffix_tokens: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PrefixCacheEntry {
+    /// Exact token sequence represented by the live device state.
+    consumed_tokens: Vec<u32>,
+    /// Logical sequence position on every participating GPU.
+    state_position: usize,
+    /// Sequence-state epoch captured before the promoting request's prefill.
+    /// An epoch change means an out-of-band path replaced the device state.
+    state_epoch: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PrefixCacheLookup {
+    Disabled,
+    Miss {
+        reason: &'static str,
+    },
+    Hit {
+        prefix_len: usize,
+        suffix_len: usize,
+    },
+}
+
+/// Bookkeeping for the experimental single-lineage live-state cache.
+///
+/// This type deliberately owns token metadata only. KV and recurrent state
+/// remain in their existing device allocations. A cache entry is promoted only
+/// when `consumed_tokens` exactly describes the state position reached on all
+/// devices.
+#[derive(Debug)]
+struct HybridPrefixCache {
+    enabled: bool,
+    entry: Option<PrefixCacheEntry>,
+    stats: PrefixCacheStats,
+}
+
+impl HybridPrefixCache {
+    fn new(enabled: bool) -> Self {
+        Self {
+            enabled,
+            entry: None,
+            stats: PrefixCacheStats::default(),
+        }
+    }
+
+    fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    fn lookup(
+        &mut self,
+        prompt_tokens: &[u32],
+        eligible: bool,
+        current_epoch: u64,
+    ) -> PrefixCacheLookup {
+        if !self.enabled {
+            return PrefixCacheLookup::Disabled;
+        }
+
+        self.stats.lookups += 1;
+        if !eligible {
+            self.invalidate();
+            self.stats.misses += 1;
+            return PrefixCacheLookup::Miss {
+                reason: "ineligible_request",
+            };
+        }
+
+        let Some(entry) = self.entry.as_ref() else {
+            self.stats.misses += 1;
+            return PrefixCacheLookup::Miss {
+                reason: "empty_cache",
+            };
+        };
+
+        if entry.state_epoch != current_epoch {
+            self.invalidate();
+            self.stats.misses += 1;
+            return PrefixCacheLookup::Miss {
+                reason: "state_epoch_changed",
+            };
+        }
+
+        if entry.state_position != entry.consumed_tokens.len() {
+            self.invalidate();
+            self.stats.misses += 1;
+            return PrefixCacheLookup::Miss {
+                reason: "state_position_mismatch",
+            };
+        }
+
+        let prefix_len = entry.consumed_tokens.len();
+        if prompt_tokens.len() <= prefix_len {
+            self.invalidate();
+            self.stats.misses += 1;
+            return PrefixCacheLookup::Miss {
+                reason: "not_an_append",
+            };
+        }
+
+        if prompt_tokens[..prefix_len] != entry.consumed_tokens {
+            self.invalidate();
+            self.stats.misses += 1;
+            return PrefixCacheLookup::Miss {
+                reason: "token_prefix_mismatch",
+            };
+        }
+
+        let suffix_len = prompt_tokens.len() - prefix_len;
+        self.stats.hits += 1;
+        self.stats.reused_tokens += prefix_len as u64;
+        self.stats.suffix_tokens += suffix_len as u64;
+        PrefixCacheLookup::Hit {
+            prefix_len,
+            suffix_len,
+        }
+    }
+
+    fn promote(
+        &mut self,
+        consumed_tokens: Vec<u32>,
+        state_position: usize,
+        state_epoch: u64,
+    ) -> Result<(), String> {
+        if !self.enabled {
+            return Ok(());
+        }
+        if consumed_tokens.is_empty() {
+            self.invalidate();
+            return Err("prefix cache cannot promote an empty state".to_string());
+        }
+        if consumed_tokens.len() != state_position {
+            self.invalidate();
+            return Err(format!(
+                "prefix cache promotion position mismatch: tokens={} state_position={}",
+                consumed_tokens.len(),
+                state_position
+            ));
+        }
+        self.entry = Some(PrefixCacheEntry {
+            consumed_tokens,
+            state_position,
+            state_epoch,
+        });
+        Ok(())
+    }
+
+    fn invalidate(&mut self) {
+        if self.entry.take().is_some() {
+            self.stats.invalidations += 1;
+        }
+    }
 }
 
 fn drain_vram_pressure_for_state(
@@ -1000,11 +1198,12 @@ fn format_completion_with_tool_calls(
 
 /// Overhead timings collected during request setup (before decode).
 struct RequestOverhead {
-    parse_ms: f64,           // HTTP parse + JSON parse + tokenization
-    evict_ms: f64,           // HCS soft-tier eviction
-    prefill_ms: f64,         // GIL acquire + Python prefill
-    reload_ms: f64,          // HCS soft-tier reload (wall-clock, includes sync if enabled)
-    real_reload_dma_ms: f64, // Actual DMA time when sync is on (0.0 if async)
+    parse_ms: f64,              // HTTP parse + JSON parse + tokenization
+    evict_ms: f64,              // HCS soft-tier eviction
+    prefill_ms: f64,            // GIL acquire + Python prefill
+    prefill_work_tokens: usize, // Tokens actually computed (excludes reused prefix)
+    reload_ms: f64,             // HCS soft-tier reload (wall-clock, includes sync if enabled)
+    real_reload_dma_ms: f64,    // Actual DMA time when sync is on (0.0 if async)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1022,12 +1221,19 @@ fn format_sse_timing(
     prefill_tok_s: f64,
     overhead_ms: f64,
     overhead: &RequestOverhead,
+    sse_timing_compat: bool,
 ) -> String {
+    let choices = if sse_timing_compat {
+        r#"[{"index":0,"delta":{},"finish_reason":null}]"#
+    } else {
+        "[]"
+    };
     format!(
-        r#"{{"id":{},"object":"chat.completion.chunk","created":{},"model":{},"choices":[],"krasis_timing":{{"decode_tokens":{},"decode_time_ms":{:.1},"decode_tok_s":{:.2},"thinking_tokens":{},"answer_tokens":{},"total_generated":{},"prompt_tokens":{},"prefill_tok_s":{:.1},"overhead_ms":{:.1},"overhead":{{"parse_ms":{:.1},"evict_ms":{:.1},"prefill_ms":{:.1},"reload_ms":{:.1},"real_reload_dma_ms":{:.1}}}}}}}"#,
+        r#"{{"id":{},"object":"chat.completion.chunk","created":{},"model":{},"choices":{},"krasis_timing":{{"decode_tokens":{},"decode_time_ms":{:.1},"decode_tok_s":{:.2},"thinking_tokens":{},"answer_tokens":{},"total_generated":{},"prompt_tokens":{},"prefill_tok_s":{:.1},"overhead_ms":{:.1},"overhead":{{"parse_ms":{:.1},"evict_ms":{:.1},"prefill_ms":{:.1},"reload_ms":{:.1},"real_reload_dma_ms":{:.1}}}}}}}"#,
         json_string(request_id),
         created,
         json_string(model_name),
+        choices,
         decode_tokens,
         decode_time_ms,
         decode_tok_s,
@@ -1367,8 +1573,20 @@ fn handle_chat_completion(stream: &mut TcpStream, body: &str, state: &mut Server
 
     let mut prompt_hcs_snapshot: Option<(Vec<u64>, usize, usize, usize)> = None;
     let mut chat_debug_input_token_ids: Option<Vec<u32>> = None;
+    // Captured before prefill: a bump between here and promotion means an
+    // out-of-band path (benchmark_request) replaced the device state.
+    let request_state_epoch = sequence_state_epoch();
     let prefill_result: Result<
-        (usize, usize, Vec<usize>, bool, Option<serde_json::Value>),
+        (
+            usize,
+            usize,
+            Vec<usize>,
+            bool,
+            Option<serde_json::Value>,
+            Vec<u32>,
+            usize,
+            bool,
+        ),
         String,
     > = {
         // ── Rust prefill: text requests stay token-id only; image requests
@@ -1500,6 +1718,41 @@ fn handle_chat_completion(stream: &mut TcpStream, body: &str, state: &mut Server
 
         let kv_max_seq = engine.kv_max_seq;
         let kv_overflow = token_ids.len() > kv_max_seq;
+        // Overflowing prompts stay on the fully validated fresh-prefill path so
+        // their existing error contract is preserved.
+        let cache_lookup =
+            state
+                .prefix_cache
+                .lookup(&token_ids, !has_images && !kv_overflow, request_state_epoch);
+        let mut continuation_prefix_len = match cache_lookup {
+            PrefixCacheLookup::Hit {
+                prefix_len,
+                suffix_len,
+            } => {
+                log::info!(
+                    "prefix_cache=hit reason=exact_append cached={} reused={} suffix={}",
+                    prefix_len,
+                    prefix_len,
+                    suffix_len,
+                );
+                Some(prefix_len)
+            }
+            PrefixCacheLookup::Miss { reason } => {
+                log::info!(
+                    "prefix_cache=miss reason={} cached=0 reused=0 suffix={}",
+                    reason,
+                    token_ids.len(),
+                );
+                None
+            }
+            PrefixCacheLookup::Disabled => {
+                log::info!(
+                    "prefix_cache=disabled reason=feature_off cached=0 reused=0 suffix={}",
+                    token_ids.len(),
+                );
+                None
+            }
+        };
 
         let _has_hqq_runtime_slots = {
             let store = unsafe { &mut *(state.gpu_store_addr as *mut GpuDecodeStore) };
@@ -1532,7 +1785,28 @@ fn handle_chat_completion(stream: &mut TcpStream, body: &str, state: &mut Server
             engine.set_prefill_runtime_chunk_cap(retry_cap);
 
             // Dynamically allocate scratch sized for this prompt.
-            if let Err(e) = engine.prepare_for_prefill(token_ids.len()) {
+            let prepare_result = if let Some(prefix_len) = continuation_prefix_len {
+                engine.prepare_for_continuation_prefill(
+                    token_ids.len(),
+                    token_ids.len().saturating_sub(prefix_len),
+                )
+            } else {
+                engine.prepare_for_prefill(token_ids.len())
+            };
+            if let Err(e) = prepare_result {
+                if continuation_prefix_len.take().is_some() {
+                    log::warn!(
+                        "Prefix continuation prepare failed; invalidating and retrying full prefill: {}",
+                        e
+                    );
+                    state.prefix_cache.invalidate();
+                    engine.clear_external_prefill_inputs();
+                    engine.set_optional_pinning_budget_mb(None);
+                    engine.clear_prefill_runtime_chunk_cap();
+                    let _ = engine.release_scratch();
+                    retry_cap = None;
+                    continue;
+                }
                 engine.clear_external_prefill_inputs();
                 engine.clear_prefill_hcs_guard_store_addr();
                 engine.set_optional_pinning_budget_mb(None);
@@ -1586,8 +1860,16 @@ fn handle_chat_completion(stream: &mut TcpStream, body: &str, state: &mut Server
                 engine.clear_external_prefill_inputs();
             }
 
-            let attempt_result = match engine.run_prefill(&token_ids, temperature, &suppress_tokens)
-            {
+            let attempt_result = match continuation_prefix_len {
+                Some(prefix_len) => engine.run_continuation_prefill(
+                    &token_ids[prefix_len..],
+                    prefix_len,
+                    temperature,
+                    &suppress_tokens,
+                ),
+                None => engine.run_prefill(&token_ids, temperature, &suppress_tokens),
+            };
+            let attempt_result = match attempt_result {
                 Ok(r) => match engine.finalize_stage_exact_prefill_kv(r.prompt_len) {
                     Ok(()) => Ok(r),
                     Err(e) => Err(format!("KV stage export failed: {}", e)),
@@ -1598,6 +1880,24 @@ fn handle_chat_completion(stream: &mut TcpStream, body: &str, state: &mut Server
             match attempt_result {
                 Ok(r) => break Ok(r),
                 Err(e) => {
+                    if continuation_prefix_len.take().is_some() {
+                        log::warn!(
+                            "Prefix continuation mutated or failed; invalidating and retrying a full reset/prefill: {}",
+                            e
+                        );
+                        state.prefix_cache.invalidate();
+                        engine.set_optional_pinning_budget_mb(None);
+                        engine.clear_external_prefill_inputs();
+                        if let Err(release_err) = engine.release_scratch() {
+                            log::error!(
+                                "Failed to release scratch before full-prefill fallback: {}",
+                                release_err
+                            );
+                            break Err(release_err);
+                        }
+                        retry_cap = None;
+                        continue;
+                    }
                     let current_chunk = engine.scratch.max_tokens;
                     let next_retry_cap = engine.cold_staging_retry_chunk_cap();
                     if let Some(next_cap) = next_retry_cap {
@@ -1718,9 +2018,14 @@ fn handle_chat_completion(stream: &mut TcpStream, body: &str, state: &mut Server
                 };
                 // Set KV cache position on decode store so decode knows where to continue
                 let store = unsafe { &mut *(state.gpu_store_addr as *mut GpuDecodeStore) };
-                if let Err(e) = restore_store_after_rust_prefill(store, r.prompt_len) {
-                    log::error!("Failed to restore decode runtime after prefill: {}", e);
-                }
+                let prefill_state_exact =
+                    match restore_store_after_rust_prefill(store, r.prompt_len) {
+                        Ok(()) => true,
+                        Err(e) => {
+                            log::error!("Failed to restore decode runtime after prefill: {}", e);
+                            false
+                        }
+                    };
                 store.set_rope_position_delta(
                     multimodal_inputs
                         .as_ref()
@@ -1733,6 +2038,9 @@ fn handle_chat_completion(stream: &mut TcpStream, body: &str, state: &mut Server
                     stop_ids,
                     kv_overflow,
                     debug_payload,
+                    token_ids,
+                    continuation_prefix_len.unwrap_or(0),
+                    prefill_state_exact,
                 ))
             }
             Err(e) => {
@@ -1755,8 +2063,16 @@ fn handle_chat_completion(stream: &mut TcpStream, body: &str, state: &mut Server
     let prefill_gil_ms = t_prefill_gil.elapsed().as_secs_f64() * 1000.0;
     crate::vram_monitor::report_event("prefill_end");
 
-    let (first_token, prompt_len, stop_ids, kv_overflow, chat_debug_payload) = match prefill_result
-    {
+    let (
+        first_token,
+        prompt_len,
+        stop_ids,
+        kv_overflow,
+        chat_debug_payload,
+        prompt_token_ids,
+        reused_prefix_tokens,
+        mut prefill_state_exact,
+    ) = match prefill_result {
         Ok(v) => v,
         Err(e) => {
             let err_str = e.to_string();
@@ -1802,6 +2118,7 @@ fn handle_chat_completion(stream: &mut TcpStream, body: &str, state: &mut Server
             };
             let _ = send_json(stream, status, &body);
             // Cleanup on error
+            state.prefix_cache.invalidate();
             Python::with_gil(|py| {
                 let _ = state.py_model.call_method0(py, "server_cleanup");
             });
@@ -1824,6 +2141,7 @@ fn handle_chat_completion(stream: &mut TcpStream, body: &str, state: &mut Server
                 prompt_len, prompt_len,
             ),
         );
+        state.prefix_cache.invalidate();
         Python::with_gil(|py| {
             let _ = state.py_model.call_method0(py, "server_cleanup");
         });
@@ -1840,13 +2158,16 @@ fn handle_chat_completion(stream: &mut TcpStream, body: &str, state: &mut Server
             .map(|(_, free_mb)| free_mb as usize)
             .unwrap_or(free_now_mb);
         let prefill_secs = prefill_gil_ms / 1000.0;
-        let prefill_tok_s = if prefill_secs > 0.0 && prompt_len > 0 {
-            prompt_len as f64 / prefill_secs
+        let prefill_work_tokens = prompt_len.saturating_sub(reused_prefix_tokens);
+        let prefill_tok_s = if prefill_secs > 0.0 && prefill_work_tokens > 0 {
+            prefill_work_tokens as f64 / prefill_secs
         } else {
             0.0
         };
         eprintln!(
-            "  \x1b[32mprefill: {} tokens in {:.2}s ({:.1} tok/s)  VRAM: {} MB free now, {} MB min free during prefill\x1b[0m",
+            "  \x1b[32mprefill: {} computed + {} reused = {} prompt tokens in {:.2}s ({:.1} computed tok/s)  VRAM: {} MB free now, {} MB min free during prefill\x1b[0m",
+            prefill_work_tokens,
+            reused_prefix_tokens,
             prompt_len,
             prefill_secs,
             prefill_tok_s,
@@ -1854,8 +2175,10 @@ fn handle_chat_completion(stream: &mut TcpStream, body: &str, state: &mut Server
             prefill_min_free_mb,
         );
         log::info!(
-            "Request {} prefill: {} tokens in {:.2}s ({:.1} tok/s), free_now={} MB, min_free_prefill={} MB",
+            "Request {} prefill: computed_tokens={} reused_tokens={} prompt_tokens={} time={:.2}s computed_tok_s={:.1} free_now={} MB min_free_prefill={} MB",
             request_id,
+            prefill_work_tokens,
+            reused_prefix_tokens,
             prompt_len,
             prefill_secs,
             prefill_tok_s,
@@ -1874,6 +2197,7 @@ fn handle_chat_completion(stream: &mut TcpStream, body: &str, state: &mut Server
                 prompt_len, state.max_context_tokens, prompt_len, state.max_context_tokens
             ),
         );
+        state.prefix_cache.invalidate();
         Python::with_gil(|py| {
             let _ = state.py_model.call_method0(py, "server_cleanup");
         });
@@ -1961,6 +2285,7 @@ fn handle_chat_completion(stream: &mut TcpStream, body: &str, state: &mut Server
                     i + 1,
                     e
                 );
+                prefill_state_exact = false;
             }
             // Copy LA recurrent state (conv_state + recur_state) for linear attention layers
             if let Err(e) = store.copy_la_states_to_aux(aux_store, layer_start, layer_end) {
@@ -1970,6 +2295,16 @@ fn handle_chat_completion(stream: &mut TcpStream, body: &str, state: &mut Server
                     i + 1,
                     e
                 );
+                prefill_state_exact = false;
+            }
+            if let Err(e) = store.copy_mamba2_states_to_aux(aux_store, layer_start, layer_end) {
+                log::error!(
+                    "Request {}: Mamba2 state copy to aux GPU{} failed: {}",
+                    request_id,
+                    i + 1,
+                    e
+                );
+                prefill_state_exact = false;
             }
         }
         let kvcopy_ms = t_kvcopy.elapsed().as_secs_f64() * 1000.0;
@@ -2034,6 +2369,7 @@ fn handle_chat_completion(stream: &mut TcpStream, body: &str, state: &mut Server
         parse_ms,
         evict_ms,
         prefill_ms: prefill_gil_ms,
+        prefill_work_tokens: prompt_len.saturating_sub(reused_prefix_tokens),
         reload_ms,                          // includes sync wait
         real_reload_dma_ms: real_reload_ms, // actual DMA time (0 if async)
     };
@@ -2066,7 +2402,7 @@ fn handle_chat_completion(stream: &mut TcpStream, body: &str, state: &mut Server
 
     // ── GPU decode: GIL-free Rust decode via GpuDecodeStore ──
     crate::vram_monitor::report_event("decode_start");
-    handle_gpu_decode(
+    let decode_outcome = handle_gpu_decode(
         stream,
         is_stream,
         state,
@@ -2091,11 +2427,98 @@ fn handle_chat_completion(stream: &mut TcpStream, body: &str, state: &mut Server
     );
     crate::vram_monitor::report_event("decode_end");
 
+    let mut preserve_sequence_state = false;
+    if state.prefix_cache.enabled() {
+        if prefill_state_exact && decode_outcome.exact_state {
+            let state_position =
+                prompt_len.saturating_add(decode_outcome.consumed_completion_tokens.len());
+            match gather_multi_gpu_sequence_state(state, store, state_position) {
+                Ok(()) => {
+                    let mut consumed_tokens = prompt_token_ids;
+                    consumed_tokens.extend_from_slice(&decode_outcome.consumed_completion_tokens);
+                    match state.prefix_cache.promote(
+                        consumed_tokens,
+                        state_position,
+                        request_state_epoch,
+                    ) {
+                        Ok(()) => {
+                            preserve_sequence_state = true;
+                            log::info!(
+                                "prefix_cache=promote source={} state_tokens={} completion_consumed={} exact_state=true",
+                                if reused_prefix_tokens > 0 { "hit" } else { "miss" },
+                                state_position,
+                                decode_outcome.consumed_completion_tokens.len(),
+                            );
+                        }
+                        Err(e) => {
+                            log::warn!(
+                                "prefix_cache=invalidate reason=promotion_failed error={}",
+                                e
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    state.prefix_cache.invalidate();
+                    log::warn!(
+                        "prefix_cache=invalidate reason=multi_gpu_state_gather_failed error={}",
+                        e
+                    );
+                }
+            }
+        } else {
+            state.prefix_cache.invalidate();
+            log::info!(
+                "prefix_cache=invalidate reason={}",
+                if prefill_state_exact {
+                    "inexact_decode_state"
+                } else {
+                    "inexact_prefill_restore"
+                }
+            );
+        }
+    }
+
     // ── Cleanup (GIL required) ──
     let t_cleanup_gil = Instant::now();
-    Python::with_gil(|py| {
-        let _ = state.py_model.call_method0(py, "server_cleanup");
+    let cleanup_result: Result<(), String> = Python::with_gil(|py| {
+        state
+            .py_model
+            .call_method1(py, "server_cleanup", (preserve_sequence_state,))
+            .map(|_| ())
+            .map_err(|e| e.to_string())
     });
+    if let Err(e) = cleanup_result {
+        log::error!("Request {}: server cleanup failed: {}", request_id, e);
+        if preserve_sequence_state {
+            state.prefix_cache.invalidate();
+            log::warn!("prefix_cache=invalidate reason=preserving_cleanup_failed");
+            // Best effort full reset: no cache entry may survive a partial
+            // preserving cleanup.
+            Python::with_gil(|py| {
+                if let Err(reset_err) = state.py_model.call_method1(py, "server_cleanup", (false,))
+                {
+                    log::error!(
+                        "Request {}: full cleanup retry failed: {}",
+                        request_id,
+                        reset_err
+                    );
+                }
+            });
+        }
+    }
+    if state.prefix_cache.enabled() {
+        let stats = state.prefix_cache.stats;
+        log::info!(
+            "prefix_cache_stats lookups={} hits={} misses={} invalidations={} reused_tokens={} suffix_tokens={}",
+            stats.lookups,
+            stats.hits,
+            stats.misses,
+            stats.invalidations,
+            stats.reused_tokens,
+            stats.suffix_tokens,
+        );
+    }
     let cleanup_gil_ms = t_cleanup_gil.elapsed().as_secs_f64() * 1000.0;
     crate::vram_monitor::report_event("cleanup_end");
     let (cleanup_pressure_evicted, cleanup_pressure_freed_mb, cleanup_pressure_final_free_mb) =
@@ -2242,6 +2665,10 @@ fn handle_prefill_logits(stream: &mut TcpStream, body: &str, state: &mut ServerS
         sample_every,
         target_token_ids.is_some()
     );
+
+    // Diagnostic prefills replace live sequence state and therefore end any
+    // production continuation lineage.
+    state.prefix_cache.invalidate();
 
     // Evict soft HCS before diagnostic prefill so this endpoint uses the same
     // conservative VRAM budget as the production and reference-test paths.
@@ -2961,6 +3388,10 @@ fn handle_reference_test(stream: &mut TcpStream, body: &str, state: &mut ServerS
 
     let mut debug_hcs_transition_points: Vec<serde_json::Value> = Vec::new();
     let mut debug_mamba2_state_lifecycle_points: Vec<serde_json::Value> = Vec::new();
+
+    // Reference diagnostics replace live sequence state and therefore end any
+    // production continuation lineage.
+    state.prefix_cache.invalidate();
 
     // ── Evict soft HCS before prefill ──
     let prefill_entry_floor_bytes =
@@ -3798,6 +4229,63 @@ fn handle_reference_test(stream: &mut TcpStream, body: &str, state: &mut ServerS
 
 /// GPU decode: GIL-free Rust decode loop via GpuDecodeStore.
 /// Pure Rust, zero Python per token.
+#[derive(Debug, Default)]
+struct DecodeOutcome {
+    /// Completion tokens that were actually consumed into device state.
+    /// The final emitted token is intentionally excluded because decode emits
+    /// it after consuming the preceding token.
+    consumed_completion_tokens: Vec<u32>,
+    /// True only for a normal stop/length boundary (or a one-token response
+    /// requiring no decode step). Errors and disconnects remain ineligible.
+    exact_state: bool,
+}
+
+fn consumed_completion_tokens(first_token: usize, emitted_tokens: &[u32]) -> Vec<u32> {
+    if emitted_tokens.is_empty() {
+        return Vec::new();
+    }
+    let mut consumed = Vec::with_capacity(emitted_tokens.len());
+    consumed.push(first_token as u32);
+    consumed.extend_from_slice(&emitted_tokens[..emitted_tokens.len() - 1]);
+    consumed
+}
+
+fn gather_multi_gpu_sequence_state(
+    state: &ServerState,
+    primary_store: &mut GpuDecodeStore,
+    state_position: usize,
+) -> Result<(), String> {
+    if state.aux_gpu_store_addrs.is_empty() {
+        return Ok(());
+    }
+
+    let num_aux = state.aux_gpu_store_addrs.len();
+    let num_layers = primary_store.num_layers();
+    for i in 0..num_aux {
+        let aux_store = unsafe { &mut *(state.aux_gpu_store_addrs[i] as *mut GpuDecodeStore) };
+        let layer_start = state.multi_gpu_split_layers[i];
+        let layer_end = if i + 1 < num_aux {
+            state.multi_gpu_split_layers[i + 1]
+        } else {
+            num_layers
+        };
+
+        // Multi-GPU decode mutates each layer only on its owning device.
+        // Gather those exact sequence states back to the primary store so the
+        // next continuation prefill has one authoritative state image.
+        aux_store.copy_kv_to_aux(
+            primary_store,
+            layer_start,
+            layer_end,
+            state.multi_gpu_gqa_offsets[i],
+            state_position,
+        )?;
+        aux_store.copy_la_states_to_aux(primary_store, layer_start, layer_end)?;
+        aux_store.copy_mamba2_states_to_aux(primary_store, layer_start, layer_end)?;
+    }
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 fn handle_gpu_decode(
     stream: &mut TcpStream,
@@ -3821,7 +4309,7 @@ fn handle_gpu_decode(
     enable_thinking: bool,
     logprobs_top_n: usize,
     chat_debug_payload: Option<serde_json::Value>,
-) {
+) -> DecodeOutcome {
     let mut chat_debug_payload = chat_debug_payload;
     // Resolve thinking end token early — used by both streaming and non-streaming paths
     let think_end_id = if enable_thinking {
@@ -3834,11 +4322,16 @@ fn handle_gpu_decode(
     } else {
         state.thinking_end_token
     };
+    // Speculative decode batches draft tokens through device state and rolls
+    // linear-attention state back around the emitted boundary, so per-token
+    // consumed accounting cannot certify an exact retained state. Never promote
+    // a prefix-cache entry for a request that could have used the draft model.
+    let speculative_decode_possible = store.has_draft_model();
 
     if is_stream {
         if let Err(e) = begin_sse(stream) {
             log::error!("Failed to send SSE headers: {}", e);
-            return;
+            return DecodeOutcome::default();
         }
 
         let first_text = tokenizer
@@ -3869,7 +4362,7 @@ fn handle_gpu_decode(
             Ok(s) => s,
             Err(e) => {
                 log::error!("Failed to clone stream for writer: {}", e);
-                return;
+                return DecodeOutcome::default();
             }
         };
 
@@ -3919,6 +4412,9 @@ fn handle_gpu_decode(
 
         let decode_start = Instant::now();
         let mut decode_token_count = 0usize;
+        let mut emitted_token_ids: Vec<u32> = Vec::new();
+        let mut exact_state = false;
+        let track_prefix_state = state.prefix_cache.enabled();
 
         // ── Thinking budget tracking ──
         // When thinking is enabled, tokens inside <think>...</think> are exempt
@@ -3971,6 +4467,9 @@ fn handle_gpu_decode(
                             token_logprobs: Option<&[(u32, f32)]>|
          -> bool {
             decode_token_count += 1;
+            if track_prefix_state {
+                emitted_token_ids.push(token_id as u32);
+            }
 
             // ── Track thinking state ──
             // Tokens before </think> are "thinking" and don't count against max_tokens.
@@ -3994,6 +4493,9 @@ fn handle_gpu_decode(
             } else {
                 None
             };
+            if effective_finish.is_some() {
+                exact_state = true;
+            }
             let hide_text =
                 hide_synthetic_think_stop_text(token_id, effective_finish, hidden_think_stop_id);
             let visible_text = if hide_text { "" } else { text };
@@ -4071,7 +4573,6 @@ fn handle_gpu_decode(
         } else {
             max_tokens.saturating_sub(1)
         };
-
         if !state.aux_gpu_store_addrs.is_empty() {
             // Multi-GPU decode: pipeline across N GPUs
             store.gpu_generate_stream_multi(
@@ -4107,6 +4608,11 @@ fn handle_gpu_decode(
                 Some(format!("chat_{}", request_id)),
                 on_token,
             );
+        }
+        if decode_budget == 0 {
+            // One-token responses run no decode step; device state still exactly
+            // represents the prompt.
+            exact_state = true;
         }
 
         // Capture decode timing BEFORE post-generation processing (tool call parsing etc.)
@@ -4174,8 +4680,8 @@ fn handle_gpu_decode(
             0.0
         };
         let decode_ms = elapsed * 1000.0;
-        let prefill_tok_s = if overhead.prefill_ms > 0.0 && prompt_len > 0 {
-            prompt_len as f64 / (overhead.prefill_ms / 1000.0)
+        let prefill_tok_s = if overhead.prefill_ms > 0.0 && overhead.prefill_work_tokens > 0 {
+            overhead.prefill_work_tokens as f64 / (overhead.prefill_ms / 1000.0)
         } else {
             0.0
         };
@@ -4195,6 +4701,7 @@ fn handle_gpu_decode(
             prefill_tok_s,
             overhead_total_ms,
             overhead,
+            state.sse_timing_compat,
         );
         let _ = tx.send(format!("data: {}\n\n", timing_chunk));
         let _ = tx.send("data: [DONE]\n\n".to_string());
@@ -4206,6 +4713,14 @@ fn handle_gpu_decode(
             request_id, elapsed, total_gen, decode_tok_s,
             overhead_total_ms, overhead.parse_ms, overhead.evict_ms, overhead.prefill_ms, overhead.reload_ms
         );
+        DecodeOutcome {
+            consumed_completion_tokens: if track_prefix_state {
+                consumed_completion_tokens(first_token, &emitted_token_ids)
+            } else {
+                Vec::new()
+            },
+            exact_state: exact_state && !speculative_decode_possible,
+        }
     } else {
         // ── Non-streaming path ──
         let mut all_text = String::new();
@@ -4219,6 +4734,9 @@ fn handle_gpu_decode(
         all_text.push_str(&first_text);
         let mut total_tokens = 1usize;
         let mut finish = "length".to_string();
+        let mut emitted_token_ids: Vec<u32> = Vec::new();
+        let mut exact_state = false;
+        let track_prefix_state = state.prefix_cache.enabled();
         let mut debug_output_tokens: Vec<(usize, Vec<(u32, f32)>)> = Vec::new();
         if chat_debug_payload.is_some() {
             debug_output_tokens.push((first_token, Vec::new()));
@@ -4241,6 +4759,9 @@ fn handle_gpu_decode(
         } else {
             max_tokens.saturating_sub(1)
         };
+        if ns_decode_budget == 0 {
+            exact_state = true;
+        }
 
         {
             let mut on_token = |token_id: usize,
@@ -4248,6 +4769,9 @@ fn handle_gpu_decode(
                                 finish_reason: Option<&str>,
                                 token_logprobs: Option<&[(u32, f32)]>|
              -> bool {
+                if track_prefix_state {
+                    emitted_token_ids.push(token_id as u32);
+                }
                 let hide_text =
                     hide_synthetic_think_stop_text(token_id, finish_reason, hidden_think_stop_id);
                 if !hide_text {
@@ -4274,11 +4798,13 @@ fn handle_gpu_decode(
 
                 if let Some(fr) = finish_reason {
                     finish = fr.to_string();
+                    exact_state = true;
                 }
 
                 // Stop if answer limit reached
                 if ns_think_end_id.is_some() && !ns_in_thinking && ns_answer_tokens >= max_tokens {
                     finish = "length".to_string();
+                    exact_state = true;
                     return false;
                 }
 
@@ -4414,6 +4940,14 @@ fn handle_gpu_decode(
             );
             let _ = send_json(stream, 200, &response);
         }
+        DecodeOutcome {
+            consumed_completion_tokens: if track_prefix_state {
+                consumed_completion_tokens(first_token, &emitted_token_ids)
+            } else {
+                Vec::new()
+            },
+            exact_state: exact_state && !speculative_decode_possible,
+        }
     }
 }
 
@@ -4441,12 +4975,16 @@ pub struct RustServer {
     prefill_engine: Arc<std::sync::Mutex<Option<crate::gpu_prefill::PrefillEngine>>>,
     /// Enable test-only endpoints (/v1/internal/prefill_logits)
     test_endpoints: bool,
+    /// Experimental exact-prefix KV + recurrent-state reuse.
+    prefix_cache_enabled: bool,
+    /// OpenAI-client compatibility for the trailing timing SSE chunk.
+    sse_timing_compat: bool,
 }
 
 #[pymethods]
 impl RustServer {
     #[new]
-    #[pyo3(signature = (py_model, host, port, model_name, tokenizer_path, max_context_tokens, enable_thinking=true, thinking_end_token_id=0, gpu_store_addr=0, aux_gpu_store_addrs=Vec::new(), multi_gpu_split_layers=Vec::new(), multi_gpu_gqa_offsets=Vec::new(), supports_vision=false, test_endpoints=false))]
+    #[pyo3(signature = (py_model, host, port, model_name, tokenizer_path, max_context_tokens, enable_thinking=true, thinking_end_token_id=0, gpu_store_addr=0, aux_gpu_store_addrs=Vec::new(), multi_gpu_split_layers=Vec::new(), multi_gpu_gqa_offsets=Vec::new(), supports_vision=false, test_endpoints=false, prefix_cache_enabled=false, sse_timing_compat=false))]
     fn new(
         py_model: PyObject,
         host: String,
@@ -4462,6 +5000,8 @@ impl RustServer {
         multi_gpu_gqa_offsets: Vec<usize>,
         supports_vision: bool,
         test_endpoints: bool,
+        prefix_cache_enabled: bool,
+        sse_timing_compat: bool,
     ) -> Self {
         // Take the pre-allocated Rust prefill engine from the decode store.
         // The engine was pre-allocated from Python (before HCS pool loading)
@@ -4512,6 +5052,8 @@ impl RustServer {
             supports_vision,
             prefill_engine: Arc::new(std::sync::Mutex::new(prefill_engine)),
             test_endpoints,
+            prefix_cache_enabled,
+            sse_timing_compat,
         }
     }
 
@@ -4532,6 +5074,8 @@ impl RustServer {
         let multi_gpu_split_layers = self.multi_gpu_split_layers.clone();
         let multi_gpu_gqa_offsets = self.multi_gpu_gqa_offsets.clone();
         let test_endpoints = self.test_endpoints;
+        let prefix_cache_enabled = self.prefix_cache_enabled;
+        let sse_timing_compat = self.sse_timing_compat;
         let running = self.running.clone();
 
         // Install raw SIGINT + SIGTERM handlers BEFORE releasing the GIL.
@@ -4709,7 +5253,17 @@ impl RustServer {
                 rust_prefill,
                 eos_stop_ids,
                 reference_test_request_order: 0,
+                prefix_cache: HybridPrefixCache::new(prefix_cache_enabled),
+                sse_timing_compat,
             };
+            log::info!(
+                "Experimental hybrid prefix-state cache: {}",
+                if state.prefix_cache.enabled() {
+                    "enabled"
+                } else {
+                    "disabled"
+                }
+            );
 
             let server_info = ServerInfo {
                 model_name: state.model_name.clone(),
@@ -4829,6 +5383,10 @@ impl RustServer {
         temperature: f32,
         enable_thinking: bool,
     ) -> PyResult<String> {
+        // This entry point mutates GPU sequence state outside the request loop
+        // and has no access to `ServerState`. Bump the sequence-state epoch on
+        // entry and exit so any prefix-cache entry spanning this call misses.
+        let _sequence_state_epoch_guard = SequenceStateEpochGuard::new();
         let benchmark_prefill_breakdown =
             std::env::var("KRASIS_BENCHMARK_PREFILL_BREAKDOWN").is_ok();
 
@@ -5462,10 +6020,11 @@ impl RustServer {
 #[cfg(test)]
 mod tests {
     use super::{
-        format_completion, format_completion_with_debug, format_completion_with_tool_calls,
-        format_models_response, format_sse_timing, format_sse_token, format_sse_tool_call_args,
-        format_sse_tool_call_start, hide_synthetic_think_stop_text, is_chat_completions_endpoint,
-        is_models_endpoint, ParsedToolCall, RequestOverhead,
+        consumed_completion_tokens, format_completion, format_completion_with_debug,
+        format_completion_with_tool_calls, format_models_response, format_sse_timing,
+        format_sse_token, format_sse_tool_call_args, format_sse_tool_call_start,
+        hide_synthetic_think_stop_text, is_chat_completions_endpoint, is_models_endpoint,
+        HybridPrefixCache, ParsedToolCall, PrefixCacheLookup, RequestOverhead,
     };
 
     const WINDOWS_MODEL_PATH: &str = r#"C:\Users\stoate\.krasis\models\Qwen3.6-35B-A3B"#;
@@ -5474,6 +6033,117 @@ mod tests {
         serde_json::from_str(body).unwrap_or_else(|e| {
             panic!("response is not valid JSON: {e}\nbody: {body}");
         })
+    }
+
+    #[test]
+    fn prefix_cache_is_disabled_by_default() {
+        let mut cache = HybridPrefixCache::new(false);
+        cache.promote(vec![1, 2, 3], 3, 0).unwrap();
+        assert_eq!(
+            cache.lookup(&[1, 2, 3, 4], true, 0),
+            PrefixCacheLookup::Disabled
+        );
+        assert_eq!(cache.stats.lookups, 0);
+        assert!(cache.entry.is_none());
+    }
+
+    #[test]
+    fn prefix_cache_hits_only_on_an_exact_nonempty_append() {
+        let mut cache = HybridPrefixCache::new(true);
+        cache.promote(vec![10, 20, 30], 3, 0).unwrap();
+        assert_eq!(
+            cache.lookup(&[10, 20, 30, 40, 50], true, 0),
+            PrefixCacheLookup::Hit {
+                prefix_len: 3,
+                suffix_len: 2,
+            }
+        );
+        assert_eq!(cache.stats.lookups, 1);
+        assert_eq!(cache.stats.hits, 1);
+        assert_eq!(cache.stats.reused_tokens, 3);
+        assert_eq!(cache.stats.suffix_tokens, 2);
+    }
+
+    #[test]
+    fn prefix_cache_mismatch_invalidates_live_state() {
+        let mut cache = HybridPrefixCache::new(true);
+        cache.promote(vec![10, 20, 30], 3, 0).unwrap();
+        assert_eq!(
+            cache.lookup(&[10, 99, 30, 40], true, 0),
+            PrefixCacheLookup::Miss {
+                reason: "token_prefix_mismatch",
+            }
+        );
+        assert!(cache.entry.is_none());
+        assert_eq!(cache.stats.invalidations, 1);
+    }
+
+    #[test]
+    fn prefix_cache_rejects_equal_prompt_and_bad_position() {
+        let mut cache = HybridPrefixCache::new(true);
+        assert!(cache.promote(vec![1, 2, 3], 2, 0).is_err());
+        assert!(cache.entry.is_none());
+
+        cache.promote(vec![1, 2, 3], 3, 0).unwrap();
+        assert_eq!(
+            cache.lookup(&[1, 2, 3], true, 0),
+            PrefixCacheLookup::Miss {
+                reason: "not_an_append",
+            }
+        );
+        assert!(cache.entry.is_none());
+    }
+
+    #[test]
+    fn prefix_cache_ineligible_request_invalidates_live_state() {
+        let mut cache = HybridPrefixCache::new(true);
+        cache.promote(vec![1, 2, 3], 3, 0).unwrap();
+        assert_eq!(
+            cache.lookup(&[1, 2, 3, 4], false, 0),
+            PrefixCacheLookup::Miss {
+                reason: "ineligible_request",
+            }
+        );
+        assert!(cache.entry.is_none());
+    }
+
+    #[test]
+    fn prefix_cache_epoch_change_invalidates_live_state() {
+        // An out-of-band state mutation (benchmark_request) bumps the
+        // sequence-state epoch; a retained entry from an older epoch must miss
+        // even when the token prefix still matches.
+        let mut cache = HybridPrefixCache::new(true);
+        cache.promote(vec![1, 2, 3], 3, 4).unwrap();
+        assert_eq!(
+            cache.lookup(&[1, 2, 3, 4], true, 6),
+            PrefixCacheLookup::Miss {
+                reason: "state_epoch_changed",
+            }
+        );
+        assert!(cache.entry.is_none());
+        assert_eq!(cache.stats.invalidations, 1);
+
+        cache.promote(vec![1, 2, 3], 3, 6).unwrap();
+        assert_eq!(
+            cache.lookup(&[1, 2, 3, 4], true, 6),
+            PrefixCacheLookup::Hit {
+                prefix_len: 3,
+                suffix_len: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn consumed_completion_tokens_match_device_decode_position() {
+        // Prefill selects `first_token` but does not consume it. Each decode
+        // callback emits a token after consuming the preceding token, so the
+        // final emitted token is not yet represented by device state.
+        assert!(consumed_completion_tokens(10, &[]).is_empty());
+        assert_eq!(consumed_completion_tokens(10, &[20]), vec![10]);
+        assert_eq!(
+            consumed_completion_tokens(10, &[20, 30, 40]),
+            vec![10, 20, 30]
+        );
     }
 
     #[test]
@@ -5613,6 +6283,7 @@ mod tests {
             parse_ms: 1.0,
             evict_ms: 2.0,
             prefill_ms: 3.0,
+            prefill_work_tokens: 17,
             reload_ms: 4.0,
             real_reload_dma_ms: 5.0,
         };
@@ -5630,10 +6301,32 @@ mod tests {
             200.0,
             10.0,
             &overhead,
+            false,
         );
         let timing_json = parse_response(&timing);
         assert_eq!(timing_json["model"], WINDOWS_MODEL_PATH);
+        assert_eq!(timing_json["choices"].as_array().unwrap().len(), 0);
         assert_eq!(timing_json["krasis_timing"]["decode_tokens"], 7);
+
+        let compatible_timing = format_sse_timing(
+            "chatcmpl-test",
+            WINDOWS_MODEL_PATH,
+            123,
+            7,
+            70.0,
+            100.0,
+            0,
+            8,
+            8,
+            17,
+            200.0,
+            10.0,
+            &overhead,
+            true,
+        );
+        let compatible_json = parse_response(&compatible_timing);
+        assert_eq!(compatible_json["choices"][0]["index"], 0);
+        assert!(compatible_json["choices"][0]["delta"].is_object());
     }
 
     #[test]

--- a/tests/test_launcher_matrix.py
+++ b/tests/test_launcher_matrix.py
@@ -147,6 +147,14 @@ def _run_server_start_smoke(config_path: Path, scenario: str, expected_fragments
 
 
 class LauncherMatrixTest(unittest.TestCase):
+    def test_experimental_protocol_and_prefix_features_default_off(self) -> None:
+        cfg = LauncherConfig()
+        self.assertFalse(cfg.prefix_cache)
+        self.assertFalse(cfg.sse_timing_compat)
+        values = cfg.to_save_dict()
+        self.assertEqual(values["CFG_PREFIX_CACHE"], "0")
+        self.assertEqual(values["CFG_SSE_TIMING_COMPAT"], "0")
+
     maxDiff = None
 
     def test_native_windows_console_key_decoding(self) -> None:
@@ -855,6 +863,8 @@ class LauncherMatrixTest(unittest.TestCase):
         cfg.force_rebuild_hqq_cache = True
         cfg.build_cache = True
         cfg.enable_thinking = False
+        cfg.prefix_cache = True
+        cfg.sse_timing_compat = True
         with tempfile.NamedTemporaryFile("w", suffix=".conf", prefix="krasis-save-roundtrip-", delete=False) as f:
             path = Path(f.name)
         try:
@@ -904,6 +914,8 @@ class LauncherMatrixTest(unittest.TestCase):
             self.assertEqual(values.get("CFG_FORCE_REBUILD_HQQ_CACHE"), "1")
             self.assertEqual(values.get("CFG_BUILD_CACHE"), "1")
             self.assertEqual(values.get("CFG_ENABLE_THINKING"), "0")
+            self.assertEqual(values.get("CFG_PREFIX_CACHE"), "1")
+            self.assertEqual(values.get("CFG_SSE_TIMING_COMPAT"), "1")
 
             loaded = LauncherConfig()
             loaded.apply_saved(launcher_mod._load_config(str(path)))
@@ -948,6 +960,8 @@ class LauncherMatrixTest(unittest.TestCase):
             self.assertTrue(loaded.force_rebuild_hqq_cache)
             self.assertTrue(loaded.build_cache)
             self.assertFalse(loaded.enable_thinking)
+            self.assertTrue(loaded.prefix_cache)
+            self.assertTrue(loaded.sse_timing_compat)
         finally:
             path.unlink(missing_ok=True)
 


### PR DESCRIPTION
I’ve been testing Krasis with Ornith-1.0-397B on four RTX 3090s. The model performed very well on short prompts, but I noticed that performance degraded dramatically over longer
  agent sessions because every API request re-prefilled the complete and continuously growing conversation history.

  On my longer software-engineering benchmark, the original behavior made extended sessions close to impractical: an initial run took approximately 124 minutes merely to reach step 50,
  at which point I stopped it. After implementing hybrid prefix-state caching, the same benchmark reached step 50 in approximately 50 minutes—about 2.5× faster—and completed all 66
  agent calls in 84 minutes.

  The improvement grows with session length because an append-only conversation no longer needs to recompute its entire prefix on every request. Krasis retains and reuses the matching
  KV and recurrent state, then computes only the appended suffix. Exact token-prefix matching protects correctness, and any mismatch automatically falls back to a normal full prefill.

  The completed benchmark recorded:

  - 65 cache hits across 66 requests
  - 1,438,981 logical prompt tokens
  - 1,411,910 reused tokens
  - Only 27,071 newly computed tokens
  - 98.12% prompt-prefix reuse

  A controlled real tool-continuation comparison using the same prompt and generated completion reduced request time from 59.39 seconds to 5.37 seconds—an 11.1× end-to-end improvement.
  Effective logical prompt throughput increased from approximately 293 to 3,242 tokens per second. The completion token IDs were identical, with a maximum selected-token log-
  probability difference of only about 0.0013.

  Another recorded pre-feature run completed only 22 calls in 82.6 minutes before timing out. The cached run completed 66 calls in 84.2 minutes, so it achieved almost three times as
  much agent progress in essentially the same wall-clock time.

  The feature is optional and disabled by default. It can be enabled using --prefix-cache or CFG_PREFIX_CACHE=1. The branch also includes an independently optional SSE timing-
  compatibility feature. The implementation was developed with GPT-5.6-sol and subsequently reviewed and hardened with Claude Fable at high effort.